### PR TITLE
feat: Add multisite support

### DIFF
--- a/includes/assets/js/scripts.js
+++ b/includes/assets/js/scripts.js
@@ -114,6 +114,7 @@ jQuery( '#wmp_fetch_posts' ).on(
 								var $wmp_pid      = res.p_id;
 								var $wmp_ptitle   = res.p_data.title;
 								var $wmp_pexcerpt = res.p_data.content;
+								var $wmp_path     = res.site_path;
 
 								// Clone preview from origin.
 								var $wmp_to_clone        = jQuery( '.wmp_generated_to_clone' ).clone();
@@ -122,7 +123,7 @@ jQuery( '#wmp_fetch_posts' ).on(
 								$counter++;
 
 								// Fields.
-								var $wmp_edit_post_link = '/wp-admin/post.php?post=' + $wmp_pid + '&action=edit';
+								var $wmp_edit_post_link = $wmp_path + 'wp-admin/post.php?post=' + $wmp_pid + '&action=edit';
 								var $wmp_post_link      = '<a class="wmp_post_fetched_view_link" href="' + $wmp_edit_post_link + '" target="_blank">(View Post)</a>';
 
 								$wmp_to_clone.find( '.wmp_post_fetched_title' ).html( $counter + '- ' + $wmp_ptitle + ' ' + $wmp_post_link );

--- a/includes/classes/class-wmpajax.php
+++ b/includes/classes/class-wmpajax.php
@@ -122,6 +122,13 @@ class WmpAjax extends WmpBase {
 								$wmp_data_temp['p_data']        = $wmp_data['data'];
 								$wmp_data_temp['p_update_post'] = $wmp_update_post;
 
+								// Add site path (multisite compatibility).
+								if ( is_multisite() && get_blog_details( get_current_blog_id() ) && isset( get_blog_details( get_current_blog_id() )->path ) ) {
+									$wmp_data_temp['site_path'] = get_blog_details( get_current_blog_id() )->path;
+								} else {
+									$wmp_data_temp['site_path'] = '/';
+								}
+
 								$fetch_posts_ret_data[] = $wmp_data_temp;
 							}
 						}

--- a/includes/classes/class-wmpassets.php
+++ b/includes/classes/class-wmpassets.php
@@ -34,7 +34,7 @@ class WmpAssets extends WmpBase {
 
 			// Scripts.
 			wp_enqueue_script( 'wmp_js_helpers', WMP_PLUGIN_URL . 'includes/assets/js/helpers.js', array( 'jquery' ), '1.0', true );
-			wp_enqueue_script( 'wmp_js_scripts', WMP_PLUGIN_URL . 'includes/assets/js/scripts.js', array( 'jquery' ), '1.0', true );
+			wp_enqueue_script( 'wmp_js_scripts', WMP_PLUGIN_URL . 'includes/assets/js/scripts.js', array( 'jquery' ), '1.1', true );
 		}
 	}
 


### PR DESCRIPTION
This PR adds multisite support to the WP-Mercury-Parser plugin:

Site 1 (check hovered URL):
<img width="1437" alt="Screen Shot 2020-01-29 at 3 16 03 PM" src="https://user-images.githubusercontent.com/10087168/73359839-684d6e80-42aa-11ea-9e8d-72b4f0ec22c6.png">

Site 2 (check hovered URL):
<img width="1438" alt="Screen Shot 2020-01-29 at 3 16 47 PM" src="https://user-images.githubusercontent.com/10087168/73359850-6edbe600-42aa-11ea-9745-0df7ba9603e1.png">
