### PR TITLE
feat: Support WordPress 5.6

### DIFF
--- a/includes/assets/css/styles.css
+++ b/includes/assets/css/styles.css
@@ -20,3 +20,12 @@
 .wmp_page .wmp_cursor {
 	cursor: pointer;
 }
+
+.wmp_page .wmp_post_toggle {
+	position: absolute;
+	right: 0;
+}
+
+.wmp_generated_cloned_posts .postbox {
+	margin-bottom: 0;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Postlight
 Tags: posts, posts importer, content parser, mercury parser
 Requires at least: 5.0
 Tested up to: 5.6
-Stable tag: v1.1
+Stable tag: v1.2
 Requires PHP: 5.6.0
 License: MIT
 License URI: https://github.com/postlight/wp-callisto-migrator/blob/master/LICENSE-MIT
@@ -34,4 +34,7 @@ Callisto will extract the content and create WordPress posts in your new or exis
 Initial release.
 
 = 1.1 =
+readme fixes/updates
+
+= 1.2 =
 CSS fix to support WordPress 5.6.

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Postlight
 Tags: posts, posts importer, content parser, mercury parser
 Requires at least: 5.0
-Tested up to: 5.3
-Stable tag: v1.0
+Tested up to: 5.6
+Stable tag: v1.1
 Requires PHP: 5.6.0
 License: MIT
 License URI: https://github.com/postlight/wp-callisto-migrator/blob/master/LICENSE-MIT
@@ -32,3 +32,6 @@ Callisto will extract the content and create WordPress posts in your new or exis
 
 = 1.0 =
 Initial release.
+
+= 1.1 =
+CSS fix to support WordPress 5.6.


### PR DESCRIPTION
## Description
This PR is to support WordPress 5.6 by applying a small accordion CSS fix by adding a new 1.2 release and updating the `Tested up to` and `Stable tag`.

## Plugins directory
This update was already pushed to the WordPress plugin directory and tagged (using the SVN recommended method) as version `1.2`:
<img width="1552" alt="Screen Shot 2020-11-30 at 12 22 46 PM" src="https://user-images.githubusercontent.com/10087168/100598629-ac186680-3307-11eb-809e-5b3b49e16d2f.png">

### Plugin page on WordPress
<img width="1552" alt="Screen Shot 2020-11-30 at 12 21 54 PM" src="https://user-images.githubusercontent.com/10087168/100598552-90ad5b80-3307-11eb-949b-0ad2ab554e65.png">
