### PR TITLE
feat: Support WordPress 5.7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/includes/assets/css/styles.css
+++ b/includes/assets/css/styles.css
@@ -25,6 +25,11 @@
 	right: 0;
 }
 
-.wmp_generated_cloned_posts .postbox {
+.wmp_page .wmp_generated_cloned_posts .postbox {
 	margin-bottom: 0;
+}
+
+.wmp_page .wmp_generated_cloned_posts .article-preview__image-container img{
+	width: 100%;
+	height: auto;
 }

--- a/includes/classes/class-wmpassets.php
+++ b/includes/classes/class-wmpassets.php
@@ -29,12 +29,15 @@ class WmpAssets extends WmpBase {
 			'toplevel_page_wmp_settings',
 		);
 		if ( in_array( $current_page, $wmp_plugin_pages, true ) ) {
-			// Styles.
-			wp_enqueue_style( 'wmp_src_css', WMP_PLUGIN_URL . 'includes/assets/css/styles.css', array(), '1.0' );
+			// Register styles and scripts.
+			wp_register_style( 'wmp_src_css', plugins_url('../assets/css/styles.css', __FILE__), array(), '1.3' );
+			wp_register_script( 'wmp_js_helpers', plugins_url('../assets/js/helpers.js', __FILE__), array( 'jquery' ), '1.3', true );
+			wp_register_script( 'wmp_js_scripts', plugins_url('../assets/js/scripts.js', __FILE__), array( 'jquery' ), '1.3', true );
 
-			// Scripts.
-			wp_enqueue_script( 'wmp_js_helpers', WMP_PLUGIN_URL . 'includes/assets/js/helpers.js', array( 'jquery' ), '1.0', true );
-			wp_enqueue_script( 'wmp_js_scripts', WMP_PLUGIN_URL . 'includes/assets/js/scripts.js', array( 'jquery' ), '1.1', true );
+			// Enqueue styles and scripts.
+			wp_enqueue_style( 'wmp_src_css' );
+			wp_enqueue_script( 'wmp_js_helpers' );
+			wp_enqueue_script( 'wmp_js_scripts' );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: postlightlabs
 Tags: posts, posts importer, content parser, mercury parser
 Requires at least: 5.0
-Tested up to: 5.6
-Stable tag: v1.2
+Tested up to: 5.7.2
+Stable tag: v1.3
 Requires PHP: 5.6.0
 License: Apache License, Version 2.0
 License URI: https://github.com/postlight/wp-callisto-migrator/blob/master/LICENSE-APACHE
@@ -35,3 +35,6 @@ readme fixes/updates
 
 = 1.2 =
 CSS fix to support WordPress 5.6.
+
+= 1.3 =
+Supporting WordPress 5.7.2.

--- a/wp-callisto-migrator.php
+++ b/wp-callisto-migrator.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Callisto Migrator
  * Plugin URI: https://mercury.postlight.com/web-parser/
  * Description: Mercury Parser for WordPress
- * Version: 1.0
+ * Version: 1.3
  * Author: Postlight
  * Author URI: https://postlight.com
  *

--- a/wp-callisto-migrator.php
+++ b/wp-callisto-migrator.php
@@ -28,7 +28,6 @@ if ( ! defined( 'WMP_PREFIX' ) ) {
 	define( 'WMP_DATE_FORMAT', 'd-m-Y' );
 
 	define( 'WMP_PLUGIN_FOLDER_NAME', 'wp-callisto-migrator' );
-	define( 'WMP_PLUGIN_URL', WP_PLUGIN_URL . '/' . WMP_PLUGIN_FOLDER_NAME . '/' );
 
 	define( 'WMP_PLUGIN_DIR', dirname( __FILE__ ) . '/' );
 


### PR DESCRIPTION
## Description
This PR is to add the `WP Callisto Migrator 1.3` update, including:
1. Registering styles and scripts before enqueuing it (which was a breaking change)
2. Fix images for previewed fetched posts
3. Add `.gitignore` to include `.DS_Store`

## Plugins directory
This update was already pushed to the WordPress plugin directory and tagged (using the SVN recommended method) as version `1.3`: https://plugins.trac.wordpress.org/browser/wp-callisto-migrator#trunk

<img width="1552" alt="Screen Shot 2021-06-24 at 3 50 49 PM" src="https://user-images.githubusercontent.com/10087168/123265700-fa8b8d80-d503-11eb-95c3-5cb6c8bbf9de.png">

### Plugin page on WordPress
https://wordpress.org/plugins/wp-callisto-migrator/#developers
<img width="1552" alt="Screen Shot 2021-06-24 at 3 51 55 PM" src="https://user-images.githubusercontent.com/10087168/123265861-24dd4b00-d504-11eb-8681-30e557aa3a54.png">

